### PR TITLE
SEC-1524: Adding ext-soap as its needed by saml2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-co
   php-mbstring php-pgsql php-phar php-pdo \
   php-simplexml php-tokenizer php-xml php-zip \
   php-memcached libmemcached-tools \
-  php-intl php-apcu ext-soap \
+  php-intl php-apcu php-soap \
   gh
 
 EOS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the container environment to include the PHP SOAP extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->