### PR TITLE
FDSF2-1268: Fix SOLR_HOCR_PLUGIN_PATH 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,7 @@ ENV CLAMAV_HOST=clamav
 ENV CLAMAV_PORT=3310
 
 # For configuration of islandora_hocr/the Solr Highlighting Plugin.
-ENV SOLR_HOME=/var/solr/data
-ENV SOLR_HOCR_PLUGIN_PATH=${SOLR_HOME}/contrib/ocrhighlighting/lib
+ENV SOLR_HOCR_PLUGIN_PATH='${solr.hocr.plugin.path:/opt/solr_extra_lib/ocrhighlighting/lib}'
 
 ENV PHP_VERSION=8.4
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

- Removes `SOLR_HOME` env var (was only used to construct `SOLR_HOCR_PLUGIN_PATH`)
- Updates `SOLR_HOCR_PLUGIN_PATH` from the hardcoded `/var/solr/data/contrib/ocrhighlighting/lib` to `'${solr.hocr.plugin.path:/opt/solr_extra_lib/ocrhighlighting/lib}'`

The `discoverygarden/solr` image moved the OCR highlighting JAR from the old path to `/opt/solr_extra_lib/ocrhighlighting/lib` and exposes it via the `solr.hocr.plugin.path` system property. The hardcoded path caused Solr cores on all FDR LAM sites to fail to load on pod restart, as `islandora_hocr` was writing the wrong path into `solrconfig_extra.xml` when uploading configsets to ZooKeeper.

This fix was already applied to the `v2` branch in PR #22. This PR brings the same change to `main`.

Validated end-to-end on `lam-stage-1` (fdr cluster) — setting the correct env var, running `drush search-api-solr:upload-configset`, and restarting the Solr pod brought the core back to GREEN.

## Test plan

- [ ] Build a new base image from this branch
- [ ] Rebuild `fdr-lam-drupal` against it
- [ ] Deploy to `lam-stage-1` and confirm `drush search-api-solr:upload-configset` writes the correct path into ZK
- [ ] Confirm Solr core comes up GREEN after pod restart without manual ZK patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Solr OCR highlighting plugin configuration to use parameterized path resolution with a fallback default, improving deployment flexibility and reducing hardcoded dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->